### PR TITLE
Make node-fetch optional

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -16,6 +16,17 @@ npm i @millihq/pixel-core next react react-dom        # squoosh
 npm i @millihq/pixel-core next react react-dom sharp  # sharp
 ```
 
+### `fetch` usage
+
+Under the hood, Next.js needs global `fetch` available to request the image from the original source.
+The module polyfills it with `node-fetch` if it is not available.
+
+If you are using a Node.js version `< 18` you should also add it as peer dependency:
+
+```sh
+npm i node-fetch
+```
+
 ## Usage
 
 Pixel can be integrated with the standard Node.js HTTP request and response model.

--- a/packages/core/lib/image-optimizer.ts
+++ b/packages/core/lib/image-optimizer.ts
@@ -12,7 +12,6 @@ import {
   defaultConfig,
   NextConfigComplete,
 } from 'next/dist/server/config-shared';
-import nodeFetch from 'node-fetch';
 
 /* -----------------------------------------------------------------------------
  * Types
@@ -60,10 +59,12 @@ type PixelOptions = {
  * ---------------------------------------------------------------------------*/
 
 // Polyfill for fetch that is used by nextImageOptimizer
-// https://github.com/vercel/next.js/blob/canary/packages/next/server/image-optimizer.ts#L223
-
-// @ts-ignore
-global.fetch = nodeFetch;
+// If we are Node.js 18+ where fetch is available we don't need the polyfill.
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/server/image-optimizer.ts#L529
+if (global.fetch === undefined) {
+  // @ts-ignore - Our types are still Node.js 14
+  global.fetch = require('node-fetch');
+}
 
 /* -----------------------------------------------------------------------------
  * Pixel

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "prepack": "cp ../../LICENSE ../../CHANGELOG.md ./",
     "postpack": "rm ./LICENSE ./CHANGELOG.md"
   },
-  "dependencies": {
+  "optionalDependencies": {
     "node-fetch": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Since Node.js 18 has native support for `node-fetch` we can mark it as an `optionalDependency`.